### PR TITLE
Resolve quotation parse issue in Symfony 3.0

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     shaygan.telegram_bot_api:
         class: Shaygan\TelegramBotApiBundle\TelegramBotApi
-        arguments: [@service_container]
+        arguments: ['@service_container']
     shaygan.my_update_receiver:
         class: Shaygan\TelegramBotApiBundle\UpdateReceiver\UpdateReceiver
-        arguments: [@shaygan.telegram_bot_api, %shaygan_telegram_bot_api.config%]
+        arguments: ['@shaygan.telegram_bot_api', '%shaygan_telegram_bot_api.config%']


### PR DESCRIPTION
Running on symfony 3 results in the following error:

```
[Symfony\Component\Yaml\Exception\ParseException]                            
  The reserved indicator "@" cannot start a plain scalar; you need to quote t  
  he scalar at line 4 (near "arguments: [@service_container]").
```

This PR resolves it by adding single quotes in services.yml.
